### PR TITLE
Add $feed->image Support

### DIFF
--- a/lib/XML/Feed.pm
+++ b/lib/XML/Feed.pm
@@ -14,7 +14,7 @@ our $VERSION = '0.49';
 our $MULTIPLE_ENCLOSURES = 0;
 our @formatters;
 BEGIN {
-	@formatters = __PACKAGE__->formatters;
+        @formatters = __PACKAGE__->formatters;
 }
 
 sub new {
@@ -78,19 +78,19 @@ sub parse {
 sub identify_format {
     my $feed   = shift;
     my($xml)   = @_;
-	foreach my $class (@formatters) {
-		my ($name) = ($class =~ m!([^:]+)$!);
-		# TODO ugly
-		my $tmp = $$xml;
-		return $name if eval { $class->identify(\$tmp) };
-		return $feed->error($@) if $@;
-	} 
-	return $feed->error("Cannot detect feed type");
+        foreach my $class (@formatters) {
+                my ($name) = ($class =~ m!([^:]+)$!);
+                # TODO ugly
+                my $tmp = $$xml;
+                return $name if eval { $class->identify(\$tmp) };
+                return $feed->error($@) if $@;
+        }
+        return $feed->error("Cannot detect feed type");
 }
 
 sub _get_first_tag {
-	my $class  = shift;
-	my ($xml)  = @_;
+        my $class  = shift;
+        my ($xml)  = @_;
 
 
     ## Auto-detect feed type based on first element. This is prone
@@ -102,9 +102,9 @@ sub _get_first_tag {
         my $first = substr $t, 0, 1;
         $tag = $t, last unless $first eq '?' || $first eq '!';
     }
-	die ("Cannot find first element") unless $tag;
+        die ("Cannot find first element") unless $tag;
     $tag =~ s/^.*://;
-	return $tag;
+        return $tag;
 }
 
 sub find_feeds {
@@ -145,7 +145,7 @@ sub _convert_entry {
     my $feed_format  = ref($feed);   $feed_format  =~ s!^XML::Feed::Format::!!;
     my $entry_format = ref($entry);  $entry_format =~ s!^XML::Feed::Entry::Format::!!;
     return $entry if $entry_format eq $feed_format;
-    return $entry->convert($feed_format); 
+    return $entry->convert($feed_format);
 }
 
 sub base;
@@ -163,6 +163,7 @@ sub add_entry;
 sub entries;
 sub as_xml;
 sub id;
+sub image;
 
 sub tagline { shift->description(@_) }
 sub items   { $_[0]->entries     }
@@ -323,6 +324,16 @@ If present, I<$modified> should be a I<DateTime> object.
 
 The generator of the feed.
 
+=head2 $feed->image
+
+=head2 $feed->image('link')
+
+=head2 $feed->image(url => $url, link => $link, title => $title)
+
+Wrapper to L<XML::RSS>'s image. Without arguments it returns the URL to the
+channel's image or logo, with a single argument it'll return the corresponding
+value, or return C<undef> otherwise.
+
 =head2 $feed->self_link ([ $uri ])
 
 The Atom Self-link of the feed:
@@ -368,7 +379,7 @@ B<Note:> Only C<XML::RSS::LibXML> version 0.3004 is known to work at the moment.
 
 =item C<$XML::Feed::MULTIPLE_ENCLOSURES>
 
-Although the RSS specification states that there can be at most one enclosure per item 
+Although the RSS specification states that there can be at most one enclosure per item
 some feeds break this rule.
 
 If this variable is set then C<XML::Feed> captures all of them and makes them available as a list.
@@ -383,9 +394,9 @@ B<Note:> C<XML::RSS> version 1.44 is needed for this to work.
 
 =head1 VALID FEEDS
 
-For reference, this cgi script will create valid, albeit nonsensical feeds 
-(according to C<http://feedvalidator.org> anyway) for Atom 1.0 and RSS 0.90, 
-0.91, 1.0 and 2.0. 
+For reference, this cgi script will create valid, albeit nonsensical feeds
+(according to C<http://feedvalidator.org> anyway) for Atom 1.0 and RSS 0.90,
+0.91, 1.0 and 2.0.
 
     #!perl -w
 

--- a/lib/XML/Feed/Format/Atom.pm
+++ b/lib/XML/Feed/Format/Atom.pm
@@ -27,7 +27,7 @@ sub identify {
 sub init_empty {
     my ($feed, %args) = @_;
     $args{'Version'} ||= '1.0';
-    
+
     $feed->{atom} = XML::Atom::Feed->new(%args);
     $feed;
 }
@@ -62,7 +62,7 @@ sub self_link {
         my $uri = shift;
         $feed->{atom}->add_link({type => "application/atom+xml", rel => "self", href => $uri});
         return $uri;
-    } 
+    }
     else
     {
         my $l =
@@ -95,8 +95,8 @@ sub author {
     }
 }
 
-
-
+# No icon or logo accessor for XML::Atom::Feed?
+sub image { ... }
 
 sub modified {
     my $feed = shift;

--- a/lib/XML/Feed/Format/RSS.pm
+++ b/lib/XML/Feed/Format/RSS.pm
@@ -26,7 +26,7 @@ sub init_empty {
     eval "use $PREFERRED_PARSER"; die $@ if $@;
     $feed->{rss} = $PREFERRED_PARSER->new(%args);
     $feed->{rss}->add_module(prefix => "content", uri => 'http://purl.org/rss/1.0/modules/content/');
-    $feed->{rss}->add_module(prefix => "dcterms", uri => 'http://purl.org/dc/terms/');    
+    $feed->{rss}->add_module(prefix => "dcterms", uri => 'http://purl.org/dc/terms/');
     $feed->{rss}->add_module(prefix => "atom", uri => 'http://www.w3.org/2005/Atom');
     $feed->{rss}->add_module(prefix => "geo", uri => 'http://www.w3.org/2003/01/geo/wgs84_pos#');
     $feed;
@@ -154,12 +154,17 @@ sub modified {
     }
 }
 
+sub image {
+    my $rss = shift->{rss};
+    @_ ? $rss->image(@_) : $rss->image('url');
+}
+
 sub entries {
     my $rss = $_[0]->{rss};
     my @entries;
     for my $item (@{ $rss->{items} }) {
         push @entries, XML::Feed::Entry::Format::RSS->wrap($item);
-		$entries[-1]->{_version} = $rss->{'version'};		
+                $entries[-1]->{_version} = $rss->{'version'};
     }
     @entries;
 }
@@ -174,4 +179,3 @@ sub add_entry {
 sub as_xml { $_[0]->{rss}->as_string }
 
 1;
-


### PR DESCRIPTION
I worked on a script over the past weekend and I had to, annoyingly, use XML::RSS directly to grab the channel's image/logo.

The changes I've made essentially place a wrapper around XML::RSS->image().

I really didn't touch that much, but my editor is setup to trim trailing whitespace and convert tabs to spaces. If it's an issue, I can redo it.

Also, this is my first go at writing something for a module. Be gentle. (^_^)
