### PR TITLE
Fixes #21 by aliasing modified() as updated().

### DIFF
--- a/lib/XML/Feed/Entry/Format/Atom.pm
+++ b/lib/XML/Feed/Entry/Format/Atom.pm
@@ -20,7 +20,7 @@ sub format { 'Atom' }
 
 sub title { shift->{entry}->title(@_) }
 sub source { shift->{entry}->source(@_) }
-sub updated { shift->{entry}->updated(@_) }
+sub updated { shift->modified(@_) }
 sub base { shift->{entry}->base(@_) }
 
 sub link {

--- a/lib/XML/Feed/Format/Atom.pm
+++ b/lib/XML/Feed/Format/Atom.pm
@@ -97,7 +97,7 @@ sub copyright   { shift->{atom}->copyright(@_) }
 sub language    { shift->{atom}->language(@_) }
 sub generator   { shift->{atom}->generator(@_) }
 sub id          { shift->{atom}->id(@_) }
-sub updated     { shift->{atom}->updated(@_) }
+sub updated     { shift->modified(@_) }
 sub add_link    { shift->{atom}->add_link(@_) }
 sub base        { shift->{atom}->base(@_) }
 


### PR DESCRIPTION
Atom 0.3 used <modified>. Atom 1.0 renamed this <updated>. If you use modified(), but have Version => 1.0, XML::Atom automatically renames it to updated().

When you call XML::Feed->modified, it formats the DateTime object using DateTime::Format::W3CDTF before passing it off to XML::Atom->modified. When you called XML::Feed->updated, it was just passing the DateTime object as-is to XML::Atom->updated, and the default stringification of DateTime doesn't include the timezone as needed by Atom.