### PR TITLE
Add timezone "Z" when formatting "floating" DateTime to W3CDTF

### DIFF
--- a/lib/XML/Feed/Entry/Format/Atom.pm
+++ b/lib/XML/Feed/Entry/Format/Atom.pm
@@ -2,11 +2,12 @@ package XML::Feed::Entry::Format::Atom;
 use strict;
 use warnings;
 
-our $VERSION = '0.53';
+our $VERSION = '0.54';
 
 use base qw( XML::Feed::Entry );
 use XML::Atom::Util qw( iso2dt );
 use XML::Feed::Content;
+use XML::Feed::Util qw( format_W3CDTF );
 use XML::Atom::Entry;
 use List::Util qw( first );
 
@@ -146,7 +147,7 @@ sub id { shift->{entry}->id(@_) }
 sub issued {
     my $entry = shift;
     if (@_) {
-        $entry->{entry}->issued(DateTime::Format::W3CDTF->format_datetime($_[0])) if $_[0];
+        $entry->{entry}->issued(format_W3CDTF($_[0])) if $_[0];
     } else {
         return iso2dt($entry->{entry}->issued)
             if $entry->{entry}->issued;
@@ -159,7 +160,7 @@ sub issued {
 sub modified {
     my $entry = shift;
     if (@_) {
-        $entry->{entry}->modified(DateTime::Format::W3CDTF->format_datetime($_[0])) if $_[0];
+        $entry->{entry}->modified(format_W3CDTF($_[0])) if $_[0];
     } else {
         return iso2dt($entry->{entry}->modified) if $entry->{entry}->modified;
         return iso2dt($entry->{entry}->updated)  if $entry->{entry}->updated;

--- a/lib/XML/Feed/Entry/Format/RSS.pm
+++ b/lib/XML/Feed/Entry/Format/RSS.pm
@@ -2,11 +2,12 @@ package XML::Feed::Entry::Format::RSS;
 use strict;
 use warnings;
 
-our $VERSION = '0.53';
+our $VERSION = '0.54';
 
 sub format { 'RSS ' . $_[0]->{'_version'} }
 
 use XML::Feed::Content;
+use XML::Feed::Util qw( format_W3CDTF );
 
 use base qw( XML::Feed::Entry );
 
@@ -137,7 +138,7 @@ sub id {
 sub issued {
     my $item = shift->{entry};
     if (@_) {
-        $item->{dc}{date} = DateTime::Format::W3CDTF->format_datetime($_[0]);
+        $item->{dc}{date} = format_W3CDTF($_[0]);
         $item->{pubDate} = DateTime::Format::Mail->format_datetime($_[0]);
     } else {
         ## Either of these could die if the format is invalid.
@@ -162,8 +163,7 @@ sub issued {
 sub modified {
     my $item = shift->{entry};
     if (@_) {
-        $item->{dcterms}{modified} =
-            DateTime::Format::W3CDTF->format_datetime($_[0]);
+        $item->{dcterms}{modified} = format_W3CDTF($_[0]);
     } else {
         if (my $ts = $item->{dcterms}{modified} ||
                 $item->{'http://www.w3.org/2005/Atom'}{updated}) {

--- a/lib/XML/Feed/Format/Atom.pm
+++ b/lib/XML/Feed/Format/Atom.pm
@@ -2,13 +2,13 @@ package XML::Feed::Format::Atom;
 use strict;
 use warnings;
 
-our $VERSION = '0.53';
+our $VERSION = '0.54';
 
 use base qw( XML::Feed );
 use XML::Atom::Feed;
 use XML::Atom::Util qw( iso2dt );
+use XML::Feed::Util qw( format_W3CDTF );
 use List::Util qw( first );
-use DateTime::Format::W3CDTF;
 use HTML::Entities;
 
 use XML::Atom::Entry;
@@ -119,7 +119,7 @@ sub image {
 sub modified {
     my $feed = shift;
     if (@_) {
-        $feed->{atom}->modified(DateTime::Format::W3CDTF->format_datetime($_[0]));
+        $feed->{atom}->modified(format_W3CDTF($_[0]));
     } else {
         return iso2dt($feed->{atom}->modified) if $feed->{atom}->modified;
         return iso2dt($feed->{atom}->updated)  if $feed->{atom}->updated;

--- a/lib/XML/Feed/Util.pm
+++ b/lib/XML/Feed/Util.pm
@@ -1,0 +1,52 @@
+package XML::Feed::Util;
+use strict;
+use warnings;
+
+our $VERSION = '0.01';
+
+use base qw( Exporter );
+use DateTime::Format::W3CDTF;
+
+our @EXPORT_OK = qw( format_W3CDTF );
+
+sub format_W3CDTF {
+    my $date = DateTime::Format::W3CDTF->format_datetime(shift);
+
+    # Add timezone "Z" if "floating" DateTime.
+    $date =~ s/(:\d\d(?:\.\d+)?)\s*$/$1Z/;
+
+    return $date;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+XML::Feed::Util - Utility functions
+
+=head1 SYNOPSIS
+
+    use XML::Feed::Util qw( format_W3CDTF );
+    use DateTime;
+    
+    print format_W3CDTF(DateTime->now);
+
+=head1 DESCRIPTION
+
+Common utility or helper functions.
+
+=head1 USAGE
+
+=head2 format_W3CDTF($date)
+
+Convert DateTime object to W3CDTF format string.
+Uses default timezone "Z" for "floating" DateTime.
+
+=head1 AUTHOR & COPYRIGHT
+
+Please see the I<XML::Feed> manpage for author, copyright, and license
+information.
+
+=cut

--- a/t/25-date-format-bug.t
+++ b/t/25-date-format-bug.t
@@ -9,9 +9,14 @@ use XML::Feed;
 use XML::Feed::Entry;
 
 # https://rt.cpan.org/Public/Bug/Display.html?id=48337
+# https://rt.cpan.org/Public/Bug/Display.html?id=103405
 
 my $feed = XML::Feed->new('Atom');
-my $dt = DateTime->now();
+
+# Bugs are with "floating" DateTime, so explicitly set time_zone.
+# DateTime->new() defaults to "floating" (usually) but DateTime->now()
+# defaults to "UTC".
+my $dt = DateTime->now(time_zone => 'floating');
 
 $feed->title("My Atom feed");
 $feed->link("http://www.example.com");


### PR DESCRIPTION
For issue #28, where feeds with invalid dates (missing timezone) were created from "floating" DateTime.