### PR TITLE
Fix accessing RSS item content

### DIFF
--- a/t/26-content-encoded.t
+++ b/t/26-content-encoded.t
@@ -1,0 +1,45 @@
+use strict;
+use warnings;
+
+use Test::More;
+use XML::Feed;
+
+# https://rt.cpan.org/Public/Bug/Display.html?id=76738
+
+my $feed = XML::Feed->parse('t/samples/rss-content-encoded.xml');
+
+my @items = $feed->items;
+my @labels = qw/ First Second /;
+
+# XML::RSS will set $item->{content}{encoded} from <content:encoded>,
+# but set $item->{content} from <content>.
+is(ref $items[0]->unwrap->{content}, 'HASH',
+   "$labels[0] entry set <content:encoded> as HASH ref");
+ok(!ref $items[1]->unwrap->{content},
+   "$labels[1] entry set <content> as string");
+
+# Both summary() and content() access content.  Neither should die
+# trying to use a string as a HASH ref.
+#
+# Test summary() first, since setting content() will force it to a
+# HASH ref.
+for my $item (@items) {
+    my $label = shift @labels;
+    my $name = "\l$label entry";
+
+    my $summary = "$label Description";
+    is($item->summary->body, $summary,      "Get old summary from $name");
+
+    $summary = "Summary for $name";
+    ok($item->summary($summary),            "Set new summary for $name");
+    is($item->summary->body, $summary,      "Get new summary from $name");
+
+    my $content_re = qr/^$label Content/;
+    like($item->content->body, $content_re, "Get old content from $name");
+    
+    my $content = "Content for $name";
+    ok($item->content($content),            "Set new content for $name");
+    is($item->content->body, $content,      "Get new content from $name");
+}
+
+done_testing();

--- a/t/samples/rss-content-encoded.xml
+++ b/t/samples/rss-content-encoded.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<rss version="2.0"
+ xmlns:atom="http://www.w3.org/2005/Atom"
+ xmlns:blogChannel="http://backend.userland.com/blogChannelModule"
+ xmlns:content="http://purl.org/rss/1.0/modules/content/"
+ xmlns:dcterms="http://purl.org/dc/terms/"
+ xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#"
+>
+
+<channel>
+<title>My RSS feed</title>
+<link>http://www.example.com</link>
+<description>Description</description>
+<pubDate>Thu,  4 Oct 2018 09:05:03 +0000</pubDate>
+<webMaster>Author</webMaster>
+
+<item>
+<title>First Title</title>
+<author>First Author</author>
+<guid isPermaLink="false">urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</guid>
+<pubDate>Thu,  4 Oct 2018 09:05:03 +0000</pubDate>
+<description>First Description</description>
+<content:encoded>First Content should get stored in $item->{content}{encoded} by XML::RSS</content:encoded>
+</item>
+
+<item>
+<title>Second Title</title>
+<author>Second Author</author>
+<guid isPermaLink="false">urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6b</guid>
+<pubDate>Thu,  4 Oct 2018 09:05:04 +0000</pubDate>
+<description>Second Description</description>
+<content>Second Content should get stored in $item->{content} by XML::RSS</content>
+</item>
+
+</channel>
+</rss>


### PR DESCRIPTION
For #26, where content is usually stored in $item->{content}{encoded} but sometimes stored in $item->{content}.  So $item->{content} may be either a HASH ref or a string, and code in summary() and content() need to check for this.
