### PR TITLE
Enable travis smoking for Perl 5.12 to 5.26 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ perl:
   - "5.16"
   - "5.18"
   - "5.20"
-
+  - "5.22"
+  - "5.24"
+  - "5.26"
 before_install:
   cpanm -n Devel::Cover::Report::Coveralls
 script:


### PR DESCRIPTION
This commit is adding Perl 5.22 to 5.26 to the existing travis configuration file
so we can detect issues with more recent versions of Perl.